### PR TITLE
[stable/2025.2] Pin Horizon openstacksdk 4.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN \
   --mount=type=bind,from=manila-ui,source=/,target=/src/manila-ui,readwrite \
   --mount=type=bind,from=neutron-vpnaas-dashboard,source=/,target=/src/neutron-vpnaas-dashboard,readwrite \
   --mount=type=bind,from=octavia-dashboard,source=/,target=/src/octavia-dashboard,readwrite <<EOF bash -xe
+sed -i "s/^os-service-types===.*python_version>='3.10'.*/os-service-types===1.8.2;python_version>='3.10'/" /upper-constraints.txt
+sed -i "s/^openstacksdk===.*python_version>='3.10'.*/openstacksdk===4.10.0;python_version>='3.10'/" /upper-constraints.txt
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/designate-dashboard \


### PR DESCRIPTION
## Summary
- Override the Horizon build-stage constraints to install `openstacksdk===4.10.0` for Python >=3.10.
- Pin `os-service-types===1.8.2` alongside it, matching the compatible SDK dependency set already used by `stable/2026.1`.
- Keep the override local to the Horizon image instead of changing the shared `openstack-venv-builder` image for every OpenStack service.

## Context
Horizon on `stable/2025.2` still calls `port_list(..., tenant_id=...)` and passes that through `networkclient(request).ports(**params)`. `openstacksdk` gained the server-side `tenant_id` filter for the Port resource in `4.9.0`; `4.10.0` is the existing `stable/2026.1` pin, so this is the smallest branch-aligned SDK bump that contains the fix.

Nova also has `tenant_id` Neutron port filters, but those paths use `python-neutronclient` (`list_ports`) rather than OpenStackSDK, so a shared builder bump is not needed for the known failure mode.

Supersedes vexxhost/docker-openstack-venv-builder#1313.

## Validation
- Searched Horizon, Nova, and other local OpenStack service sources for SDK-style `ports(...)` usage with tenant/project filters.
- Simulated the Dockerfile constraint rewrite against `openstack/requirements stable/2025.2` and confirmed the generated pins are:
  - `os-service-types===1.8.2;python_version>='3.10'`
  - `openstacksdk===4.10.0;python_version>='3.10'`
- Ran `uv pip compile` for `openstacksdk==4.10.0` and `os-service-types==1.8.2` with the generated Python 3.12 constraints.