### PR TITLE
[stable/2025.1] Backport Horizon openstacksdk 4.10.0 pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN \
   --mount=type=bind,from=manila-ui,source=/,target=/src/manila-ui,readwrite \
   --mount=type=bind,from=neutron-vpnaas-dashboard,source=/,target=/src/neutron-vpnaas-dashboard,readwrite \
   --mount=type=bind,from=octavia-dashboard,source=/,target=/src/octavia-dashboard,readwrite <<EOF bash -xe
+sed -i 's/^os-service-types===.*/os-service-types===1.8.2/' /upper-constraints.txt
+sed -i 's/^openstacksdk===.*/openstacksdk===4.10.0/' /upper-constraints.txt
 uv pip install \
     --constraint /upper-constraints.txt \
         /src/designate-dashboard \


### PR DESCRIPTION
## Summary
- Backport the Horizon-only SDK constraint override from #969 to `stable/2025.1`.
- Pin `openstacksdk===4.10.0` so Horizon gets SDK-side `tenant_id` filtering for Neutron ports.
- Pin `os-service-types===1.8.2` alongside it so the constraints remain installable.

## Context
This keeps the fix scoped to the Horizon image instead of changing the shared `openstack-venv-builder` image used by the rest of the OpenStack service images. Nova's tenant-scoped Neutron port calls use `python-neutronclient`, not OpenStackSDK, so the broader builder bump is not needed for the known Horizon failure.

Supersedes vexxhost/docker-openstack-venv-builder#1314.

## Validation
- Searched Horizon, Nova, and other local OpenStack service sources for SDK-style `ports(...)` usage with tenant/project filters.
- Simulated the Dockerfile constraint rewrite against `openstack/requirements stable/2025.1` and confirmed the generated pins are:
  - `os-service-types===1.8.2`
  - `openstacksdk===4.10.0`
- Ran `uv pip compile` for `openstacksdk==4.10.0` and `os-service-types==1.8.2` with the generated Python 3.12 constraints.