### PR TITLE
feat: add neutron-fwaas-dashboard to 2025.2 image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,11 @@ jobs:
 
       - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
         with:
+          repository: openstack/neutron-fwaas-dashboard
+          ref: 3d1bc46f7ad2107e85adf0528c396c19b22188ea # stable/2025.2
+
+      - uses: vexxhost/docker-atmosphere/.github/actions/checkout@5923a8fba3a98cf17e36583cc498d5e70a01c482 # main
+        with:
           repository: openstack/neutron-vpnaas-dashboard
           ref: 9bf310507187b7e0d4be71a56e47ce1d103b7f23 # stable/2025.2
 
@@ -67,6 +72,7 @@ jobs:
             ironic-ui=openstack/ironic-ui
             magnum-ui=openstack/magnum-ui
             manila-ui=openstack/manila-ui
+            neutron-fwaas-dashboard=openstack/neutron-fwaas-dashboard
             neutron-vpnaas-dashboard=openstack/neutron-vpnaas-dashboard
             octavia-dashboard=openstack/octavia-dashboard
           push: ${{ github.event_name != 'pull_request' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN \
   --mount=type=bind,from=ironic-ui,source=/,target=/src/ironic-ui,readwrite \
   --mount=type=bind,from=magnum-ui,source=/,target=/src/magnum-ui,readwrite \
   --mount=type=bind,from=manila-ui,source=/,target=/src/manila-ui,readwrite \
+  --mount=type=bind,from=neutron-fwaas-dashboard,source=/,target=/src/neutron-fwaas-dashboard,readwrite \
   --mount=type=bind,from=neutron-vpnaas-dashboard,source=/,target=/src/neutron-vpnaas-dashboard,readwrite \
   --mount=type=bind,from=octavia-dashboard,source=/,target=/src/octavia-dashboard,readwrite <<EOF bash -xe
 sed -i "s/^os-service-types===.*python_version>='3.10'.*/os-service-types===1.8.2;python_version>='3.10'/" /upper-constraints.txt
@@ -21,6 +22,7 @@ uv pip install \
         /src/ironic-ui \
         /src/magnum-ui \
         /src/manila-ui \
+        /src/neutron-fwaas-dashboard \
         /src/neutron-vpnaas-dashboard \
         /src/octavia-dashboard \
         pymemcache


### PR DESCRIPTION
## Summary
- add `openstack/neutron-fwaas-dashboard` to the Horizon image build for `stable/2025.2`
- install the dashboard before `neutron-vpnaas-dashboard` to keep the `-aas` dashboards grouped
- pin the dashboard checkout to the tip of upstream `stable/2025.2`: `3d1bc46f7ad2107e85adf0528c396c19b22188ea`

## Validation
- `git diff --check`
- verified the shared `docker-atmosphere` actions remain pinned to `5923a8fba3a98cf17e36583cc498d5e70a01c482`